### PR TITLE
Format fix

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -32,8 +32,9 @@ problem, all of the source files have been converted to .dxf files,
 and added to Git. The .dxf files can be edited with multiple CAD packages,
 and serve as the 'source' files for future changes to the drawings.
 They can be converted from .dxf to postscript (not .eps) using QCAD,
-which is available for many systems
-(https://repology.org/project/qcad/versions)[![Packaging status](https://repology.org/badge/tiny-repos/qcad.svg)].
+which is available 
+image:https://repology.org/badge/tiny-repos/qcad.svg[title="Badge of available systems"] 
+and also specified on https://repology.org/project/qcad/versions[this page].
 
 Unfortunately, EasyCAD (and AutoCAD) support a number of entities
 that QCAD does not import properly. Including some that were used

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -32,7 +32,7 @@ problem, all of the source files have been converted to .dxf files,
 and added to Git. The .dxf files can be edited with multiple CAD packages,
 and serve as the 'source' files for future changes to the drawings.
 They can be converted from .dxf to postscript (not .eps) using QCAD,
-which is available for many systems image:https://repology.org/badge/tiny-repos/qcad.svg[link=https://repology.org/project/qcad/].
+which is available for many systems, see link:https://repology.org/project/qcad/[here].
 
 Unfortunately, EasyCAD (and AutoCAD) support a number of entities
 that QCAD does not import properly. Including some that were used

--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -32,9 +32,7 @@ problem, all of the source files have been converted to .dxf files,
 and added to Git. The .dxf files can be edited with multiple CAD packages,
 and serve as the 'source' files for future changes to the drawings.
 They can be converted from .dxf to postscript (not .eps) using QCAD,
-which is available 
-image:https://repology.org/badge/tiny-repos/qcad.svg[title="Badge of available systems"] 
-and also specified on https://repology.org/project/qcad/versions[this page].
+which is available for many systems image:https://repology.org/badge/tiny-repos/qcad.svg[link=https://repology.org/project/qcad/].
 
 Unfortunately, EasyCAD (and AutoCAD) support a number of entities
 that QCAD does not import properly. Including some that were used


### PR DESCRIPTION
Use ASCIIDOC format as specified at https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#images and https://docs.asciidoctor.org/asciidoc/latest/syntax-quick-reference/#links

Suggestion from https://github.com/LinuxCNC/linuxcnc/pull/1740 to target docs-devel